### PR TITLE
Add support for handling module paths across PowerShell versions

### DIFF
--- a/Install.ps1
+++ b/Install.ps1
@@ -3,7 +3,12 @@
 $ModuleRoot = "$(
   if (([System.Environment]::OSVersion.Platform -eq "Win32NT") `
         -or ($PSVersionTable.Platform -eq "Windows")) {
-    "$([Environment]::GetFolderPath("MyDocuments"))/WindowsPowerShell"
+    if ($PSVersionTable.PSVersion.Major -ge 7) {
+      "$([Environment]::GetFolderPath("MyDocuments"))/PowerShell"
+    }
+    else {
+      "$([Environment]::GetFolderPath("MyDocuments"))/WindowsPowerShell"
+    }
   }
   elseif ($env:XDG_DATA_HOME) {
     "$env:XDG_DATA_HOME/powershell"


### PR DESCRIPTION
Updated script to distinguish between PowerShell 7 (Core) and Windows PowerShell 5.1 when determining the correct module path.