### PR TITLE
Check whether fzf exists & succeeds in PowerShell

### DIFF
--- a/Workspace.psm1
+++ b/Workspace.psm1
@@ -102,7 +102,16 @@ function Enter-Workspace {
     $Workspace
   )
   if (!$Workspace) {
-    $Workspace = (Get-Workspaces | Invoke-Fzf)
+    if (Get-Command -Name fzf -ErrorAction SilentlyContinue) {
+      $NextWorkspace = (Get-Workspaces | fzf)
+      if ($LastExitCode -ne 0) {
+        return
+      }
+      $Workspace = $NextWorkspace
+    }
+    else {
+      throw "fzf not found. Install it to use the fuzzy finder functionality."
+    }
   }
 
   $WorkspacePath = (Get-WorkspacePath $Workspace)


### PR DESCRIPTION
Uses `fzf` instead of `Invoke-Fzf` which is a wrapper script that is not installed with all 'distributions' of fzf. Also includes a check, so there is a custom error message, and checks whether `fzf` was successfully run (zero exit code) to avoid an error message if the user cancels the workspace switch by pressing ESC or something like that.